### PR TITLE
Update to be compatible with poise 2.0

### DIFF
--- a/libraries/provider_automatic_updates_centos.rb
+++ b/libraries/provider_automatic_updates_centos.rb
@@ -1,6 +1,9 @@
 #
 # Copyright 2015, Rackspace
 #
+
+require 'poise'
+
 class Chef
   class Provider::AutomaticUpdatesCentOS < Provider
     include Poise

--- a/libraries/provider_automatic_updates_ubuntu.rb
+++ b/libraries/provider_automatic_updates_ubuntu.rb
@@ -1,6 +1,9 @@
 #
 # Copyright 2015, Rackspace
 #
+
+require 'poise'
+
 class Chef
   class Provider::AutomaticUpdatesUbuntu < Provider
     include Poise

--- a/libraries/resource_automatic_updates.rb
+++ b/libraries/resource_automatic_updates.rb
@@ -1,6 +1,9 @@
 #
 # Copyright 2015, Rackspace
 #
+
+require 'poise'
+
 class Chef
   class Resource::AutomaticUpdates < Resource
     include Poise


### PR DESCRIPTION
Due to a major release in poise, we now must `require 'poise'` to use `include Poise`.
