### PR TITLE
Add a parameter to specify whether to send email or not

### DIFF
--- a/libraries/rhel_helpers.rb
+++ b/libraries/rhel_helpers.rb
@@ -23,7 +23,8 @@ module AutomaticUpdates
             cookbook 'automatic_updates'
             variables(
               automatic_updates_enabled: 'yes',
-              download_only: 'no'
+              download_only: 'no',
+              automatic_updates_send_email: send_email
             )
             notifies :restart, 'service[yum-cron]', :delayed
           end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,4 +7,5 @@
 #
 automatic_updates 'default' do
   action :enable
+  send_email 'no'
 end

--- a/resources/automatic_updates.rb
+++ b/resources/automatic_updates.rb
@@ -1,6 +1,7 @@
 resource_name :automatic_updates
 
 property :name, name_property: true
+property :send_email, String, default: 'yes'
 
 default_action :enable
 

--- a/templates/default/yum-cron.conf.erb
+++ b/templates/default/yum-cron.conf.erb
@@ -10,7 +10,7 @@ update_cmd = default
 
 # Whether a message should be emitted when updates are available,
 # were downloaded, or applied.
-update_messages = yes
+update_messages = <%= @automatic_updates_send_email %>
 
 # Whether updates should be downloaded when they are available.
 download_updates = yes

--- a/test/integration/default/inspec/yum_cron_spec.rb
+++ b/test/integration/default/inspec/yum_cron_spec.rb
@@ -13,6 +13,7 @@ if os[:family] == 'redhat'
   describe file('/etc/yum/yum-cron.conf') do
     its(:content) { should match(/download_updates = yes/) }
     its(:content) { should match(/apply_updates = yes/) }
+    its(:content) { should match(/update_messages = no/) }
   end
 
   describe service('yum-cron') do


### PR DESCRIPTION
This adds a simple option for the redhat yum-cron to turn off emails, as they can get annoying. 
