### PR TITLE
Fix circle ci and testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ group :lint do
   gem 'foodcritic', '~> 3.0'
   gem 'foodcritic-rackspace-rules'
   gem 'rubocop', '~> 0.24'
+  gem 'cookstyle'
 end
 
 group :unit do
@@ -14,6 +15,7 @@ end
 
 group :kitchen_common do
   gem 'test-kitchen'
+  gem 'kitchen-inspec'
 end
 
 group :kitchen_vagrant do

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require 'bundler/setup'
 require 'rspec/core/rake_task'
+require 'cookstyle'
 require 'rubocop/rake_task'
 require 'foodcritic'
 require 'kitchen'
@@ -23,7 +24,7 @@ task style: ['style:chef', 'style:ruby']
 # Rspec and ChefSpec
 desc 'Run ChefSpec unit tests'
 RSpec::Core::RakeTask.new(:spec) do |t, args|
-  t.rspec_opts = 'test/unit'
+  t.rspec_opts = 'spec/unit'
 end
 
 # Integration tests. Kitchen.ci

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   ruby:
-    version: 2.1.5
+    version: 2.2.2
   environment:
     KITCHEN_LOCAL_YAML: .kitchen.cloud.yml
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,5 +7,4 @@
 #
 automatic_updates 'default' do
   action :enable
-  send_email 'no'
 end

--- a/spec/unit/recipes/automatic_updates_centos68_spec.rb
+++ b/spec/unit/recipes/automatic_updates_centos68_spec.rb
@@ -12,7 +12,7 @@ describe 'automatic_updates_test::* on Centos 6.8' do
     step_into: ['automatic_updates'],
   }.freeze
 
-  context 'Enable automationc_update' do
+  context 'Enable automatic_update' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(CENTOS68_OPTS) do |node|
         node_resources(node)
@@ -42,7 +42,19 @@ describe 'automatic_updates_test::* on Centos 6.8' do
     end
   end
 
-  context 'Disable automationc_update' do
+  context 'Enable automatic_update without email' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(CENTOS68_OPTS) do |node|
+        node_resources(node)
+      end.converge('automatic_updates_test::enable_noemail')
+    end
+
+    it 'enables automatic updates in yum-cron.conf' do
+      expect(chef_run).to render_file('/etc/yum/yum-cron.conf').with_content('update_messages = no')
+    end
+  end
+
+  context 'Disable automatic_update' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(CENTOS68_OPTS) do |node|
         node_resources(node)

--- a/spec/unit/recipes/automatic_updates_centos72_spec.rb
+++ b/spec/unit/recipes/automatic_updates_centos72_spec.rb
@@ -12,7 +12,7 @@ describe 'automatic_updates_test::* on Centos 7.2.1511' do
     step_into: ['automatic_updates'],
   }.freeze
 
-  context 'Enable automationc_update' do
+  context 'Enable automatic_update' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(CENTOS72_OPTS) do |node|
         node_resources(node)
@@ -42,7 +42,19 @@ describe 'automatic_updates_test::* on Centos 7.2.1511' do
     end
   end
 
-  context 'Disable automationc_update' do
+  context 'Enable automatic_update without email' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(CENTOS72_OPTS) do |node|
+        node_resources(node)
+      end.converge('automatic_updates_test::enable_noemail')
+    end
+
+    it 'enables automatic updates in yum-cron.conf' do
+      expect(chef_run).to render_file('/etc/yum/yum-cron.conf').with_content('update_messages = no')
+    end
+  end
+
+  context 'Disable automatic_update' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(CENTOS72_OPTS) do |node|
         node_resources(node)

--- a/spec/unit/recipes/automatic_updates_ubuntu1404_spec.rb
+++ b/spec/unit/recipes/automatic_updates_ubuntu1404_spec.rb
@@ -12,7 +12,7 @@ describe 'automatic_updates_test::* on Ubuntu 14.04' do
     step_into: ['automatic_updates'],
   }.freeze
 
-  context 'Enable automationc_update' do
+  context 'Enable automatic_update' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(UBUNTU1404_OPTS) do |node|
         node_resources(node)
@@ -22,7 +22,7 @@ describe 'automatic_updates_test::* on Ubuntu 14.04' do
     it_behaves_like 'enable automatic updates for Ubuntu'
   end
 
-  context 'Disable automationc_update' do
+  context 'Disable automatic_update' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(UBUNTU1404_OPTS) do |node|
         node_resources(node)

--- a/spec/unit/recipes/automatic_updates_ubuntu1604_spec.rb
+++ b/spec/unit/recipes/automatic_updates_ubuntu1604_spec.rb
@@ -12,7 +12,7 @@ describe 'automatic_updates_test::* on Ubuntu 16.04' do
     step_into: ['automatic_updates'],
   }.freeze
 
-  context 'Enable automationc_update' do
+  context 'Enable automatic_update' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(UBUNTU1604_OPTS) do |node|
         node_resources(node)
@@ -22,7 +22,7 @@ describe 'automatic_updates_test::* on Ubuntu 16.04' do
     it_behaves_like 'enable automatic updates for Ubuntu'
   end
 
-  context 'Disable automationc_update' do
+  context 'Disable automatic_update' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(UBUNTU1604_OPTS) do |node|
         node_resources(node)

--- a/test/fixtures/cookbooks/automatic_updates_test/recipes/enable_noemail.rb
+++ b/test/fixtures/cookbooks/automatic_updates_test/recipes/enable_noemail.rb
@@ -1,0 +1,7 @@
+# comments!
+include_recipe 'disable_ipv6'
+
+automatic_updates 'default' do
+  action :enable
+  send_email 'no'
+end

--- a/test/integration/default/inspec/yum_cron_spec.rb
+++ b/test/integration/default/inspec/yum_cron_spec.rb
@@ -13,7 +13,6 @@ if os[:family] == 'redhat'
   describe file('/etc/yum/yum-cron.conf') do
     its(:content) { should match(/download_updates = yes/) }
     its(:content) { should match(/apply_updates = yes/) }
-    its(:content) { should match(/update_messages = no/) }
   end
 
   describe service('yum-cron') do


### PR DESCRIPTION
This PR overrides #18 and #19 as I couldn't get rebasing to work properly,  
comments on #19 were to pull it into 18, so now it is all here.

This gets the circle CI past the simple version issue it has been having. I also fixed up the unit test path, and Gemfile so that things seem to work a little better. 

This fixes a default change I made in #17, and then moves the testing into the spec directory so it is tested without changes the default for the recipe use.

I also fixed up some strange spellings of automatic.
